### PR TITLE
fix bug & add .vscode in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+.vscode
 .gitattributes
 *.pyc
 *.png

--- a/biliup/engine/upload.py
+++ b/biliup/engine/upload.py
@@ -19,7 +19,7 @@ class UploadBase:
     def file_list(index):
         file_list = []
         for file_name in os.listdir('.'):
-            if index in file_name:
+            if index in file_name and os.path.isfile(file_name):
                 file_list.append(file_name)
         file_list = sorted(file_list)
         return file_list


### PR DESCRIPTION
如果文件夹名中含有 `index` 字符串的内容，则会在 `UploadBase` 类中的 `file_list` 函数错误地被判断为需上传和删除的文件，最终会因为 `os.remove` 函数无法删除文件夹导致出错。
此次在 `file_list` 函数中新增了一个确认条件以保证其返回值仅包含文件而不包含文件夹，同时为了方便使用 vscode 进行调试，在 `.gitignore` 中增加了 `.vscode` 行。